### PR TITLE
Changeable breakpoint class (\@)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * `yarn add nebula-css` / [Get started](#get-started)
 * Check out [Nebula-CSS React Starter](https://github.com/rbrtsmith/nebula-css-react-starter) to see how this can be integrated into a ReactJS project.
 
-Super low-level mobile-first Sass framework using the [ITCSS](https://www.youtube.com/watch?v=1OKZOV-iLj4) architecture and the [BEM(IT)](http://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/) naming convention.  
+Super low-level mobile-first Sass framework using the [ITCSS](https://www.youtube.com/watch?v=1OKZOV-iLj4) architecture and the [BEM(IT)](http://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further/) naming convention.
 
 Rather than using 'semantic classnames' that some other frameworks push, the classnames employed in Nebula explicitly describe the underlying architecture.
 This makes it *much* easier to reason about the CSS structure from your HTML, promotes code re-use and composition; which otherwise would all be severely hindered if classnames were closely coupled with content.
@@ -109,7 +109,7 @@ Having a deep knowledge of Sass is not required to consume Nebula CSS, but a fam
 
 **This document assumes you have [NodeJS](https://nodejs.org/en/) installed on your machine.**
 
-Nebula's source code does not include any vendor prefixes.  This gives you the freedom to configure [Autoprefixer](https://github.com/postcss/autoprefixer) to the browsers that you intend to support.  
+Nebula's source code does not include any vendor prefixes.  This gives you the freedom to configure [Autoprefixer](https://github.com/postcss/autoprefixer) to the browsers that you intend to support.
 This can be ran directly in NPM scripts as you can see happening in this projects [package.json](https://github.com/rbrtsmith/nebula-css/blob/master/package.json#L9).  Alternatively you can run this in your build-tool of choice.
 
 
@@ -117,7 +117,7 @@ This can be ran directly in NPM scripts as you can see happening in this project
 1. `yarn add nebula-css` OR `npm i -S nebula-css`
 2. Setup an ITCSS file structure:
     1. `cd` into the directory where you intend to build out your ITCSS structure.
-    2. Paste the following snippet into your terminal:  
+    2. Paste the following snippet into your terminal:
     *&mdash; Windows users will have to manually create and populate the files.*
 
         ```
@@ -266,6 +266,10 @@ Base font-sizing for body copy.
 ```sass
 $nb-base-font-size: 1rem !default;
 ```
+The delimiter to use for responsive variations of classes (default `@`, but could be changed to i.e. `-bp-` to allow `composes:` as that doesn't work with `@` in class names)
+```sass
+$nb-breakpoint-class: '\\@' !default;
+```
 Breakpoints using a Sass Map. the keys `sm`, `md` are used to generate the responsive classnames.  Being a Sass map it is possible to add or remove breakpoints and of course you can change the values.
 ```sass
 $nb-breakpoints: (
@@ -274,7 +278,7 @@ $nb-breakpoints: (
   lg: 1200px
 ) !default;
 ```
-The root font-sizing set as a percentage on the `<html>` element.  
+The root font-sizing set as a percentage on the `<html>` element.
 The key `default` being the initial sizing up until the key matching the `$nb-breakpoints` key.  In this case `sm` So screens larger than 720px will get 100% root-font sizing.  Those smaller will receive 90%.
 ```sass
 $nb-root-sizing: (
@@ -434,7 +438,7 @@ The following CSS classnames would be generated:
 .o-bare-list--spaced-lg\@myKey {}
 ```
 
-As we can see in these examples the `@` symbol denotes that this class applies to a particular breakpoint, the chars after should map directly to a key in `$nb-breakpoints`.  
+As we can see in these examples the `@` symbol denotes that this class applies to a particular breakpoint, the chars after should map directly to a key in `$nb-breakpoints`.
 Also note that the `@` symbol here is escaped, this is because symbols like `@` are not strictly valid CSS selectors so they must be escaped.  However you don't need to do this when defining your classnames in your HTML.
 
 Nebula CSS also provides you with a mixin that can be use to interface with the defined breakpoints: `nb-respond-to()`  This mixin accepts a string argument.  The string should match one of the maps in `nb-breakpoints`.  e.g.

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Base font-sizing for body copy.
 ```sass
 $nb-base-font-size: 1rem !default;
 ```
-The delimiter to use for responsive variations of classes (default `@`, but could be changed to i.e. `-bp-` to allow `composes:` as that doesn't work with `@` in class names)
+The delimiter to use for responsive variations of classes. Default `@`. (Can be changed to i.e. `-bp-` to allow CSS modules' `composes:` as that doesn't work with `@` in class names)
 ```sass
 $nb-breakpoint-class: '\\@' !default;
 ```

--- a/nebula-css/_settings.scss
+++ b/nebula-css/_settings.scss
@@ -1,12 +1,12 @@
 $nb-namespace: '' !default;
 $nb-site-wrap-width: 70rem !default;
 $nb-base-font-size: 1rem !default;
-$nb-breakpoint-class: '\\@' !default;
 
 $nb-spacing-unit: 1rem !default;
 $nb-spacing-unit-half: ($nb-spacing-unit / 2) !default;
 $nb-spacing-unit-double: ($nb-spacing-unit * 2) !default;
 
+$nb-breakpoint-class: '\\@' !default;
 $nb-breakpoints: (
   xs: 480px,
   sm: 720px,

--- a/nebula-css/_settings.scss
+++ b/nebula-css/_settings.scss
@@ -1,6 +1,7 @@
 $nb-namespace: '' !default;
 $nb-site-wrap-width: 70rem !default;
 $nb-base-font-size: 1rem !default;
+$nb-breakpoint-class: '\\@' !default;
 
 $nb-spacing-unit: 1rem !default;
 $nb-spacing-unit-half: ($nb-spacing-unit / 2) !default;

--- a/nebula-css/objects/_flag.scss
+++ b/nebula-css/objects/_flag.scss
@@ -57,12 +57,12 @@
 
 @each $bp-key, $bp-value in $nb-breakpoints {
   @include nb-respond-to(#{$bp-key}) {
-    .#{$nb-namespace}o-flag\@#{$bp-key} {
+    .#{$nb-namespace}o-flag#{$nb-breakpoint-class}#{$bp-key} {
       display: table;
     }
 
-    .#{$nb-namespace}o-flag\@#{$bp-key} > .#{$nb-namespace}o-flag__body,
-    .#{$nb-namespace}o-flag\@#{$bp-key} > .#{$nb-namespace}o-flag__component {
+    .#{$nb-namespace}o-flag#{$nb-breakpoint-class}#{$bp-key} > .#{$nb-namespace}o-flag__body,
+    .#{$nb-namespace}o-flag#{$nb-breakpoint-class}#{$bp-key} > .#{$nb-namespace}o-flag__component {
       display: table-cell;
     }
 
@@ -70,11 +70,11 @@
     @each $key, $value in $nb-flag-gutter-sizes {
       // deep nesting required
       /* stylelint-disable max-nesting-depth */
-      .#{$nb-namespace}o-flag\@#{$bp-key}.#{$nb-namespace}o-flag--gutter-#{$key}.#{$nb-namespace}o-flag--reverse > .#{$nb-namespace}o-flag__component {
+      .#{$nb-namespace}o-flag#{$nb-breakpoint-class}#{$bp-key}.#{$nb-namespace}o-flag--gutter-#{$key}.#{$nb-namespace}o-flag--reverse > .#{$nb-namespace}o-flag__component {
         padding-left: $nb-spacing-unit;
       }
 
-      .#{$nb-namespace}o-flag\@#{$bp-key}.#{$nb-namespace}o-flag--gutter-#{$key}:not(.#{$nb-namespace}o-flag--reverse) > .#{$nb-namespace}o-flag__component {
+      .#{$nb-namespace}o-flag#{$nb-breakpoint-class}#{$bp-key}.#{$nb-namespace}o-flag--gutter-#{$key}:not(.#{$nb-namespace}o-flag--reverse) > .#{$nb-namespace}o-flag__component {
         padding-right: $nb-spacing-unit;
       }
       /* stylelint-enable */

--- a/nebula-css/tools/_gutters.scss
+++ b/nebula-css/tools/_gutters.scss
@@ -26,15 +26,15 @@
 
   @each $bp-key, $bp-value in $nb-breakpoints {
     @include nb-respond-to($bp-key) {
-      #{$matrix-class}.#{$nb-namespace}o-grid--gutter#{$size-key}\@#{$bp-key} {
+      #{$matrix-class}.#{$nb-namespace}o-grid--gutter#{$size-key}#{$nb-breakpoint-class}#{$bp-key} {
         margin-#{$side}: -$size-value;
       }
 
-      #{$matrix-class}.#{$nb-namespace}o-grid--gutter#{$size-key}\@#{$bp-key} > .#{$nb-namespace}o-grid__item {
+      #{$matrix-class}.#{$nb-namespace}o-grid--gutter#{$size-key}#{$nb-breakpoint-class}#{$bp-key} > .#{$nb-namespace}o-grid__item {
         padding-#{$side}: $size-value;
       }
 
-      .#{$nb-namespace}o-grid__item > #{$matrix-class}.#{$nb-namespace}o-grid--gutter#{$size-key}\@#{$bp-key} {
+      .#{$nb-namespace}o-grid__item > #{$matrix-class}.#{$nb-namespace}o-grid--gutter#{$size-key}#{$nb-breakpoint-class}#{$bp-key} {
         width: calc(100% + #{$size-value});
       }
     }

--- a/nebula-css/tools/_hidden.scss
+++ b/nebula-css/tools/_hidden.scss
@@ -1,12 +1,12 @@
 @mixin nb-hidden() {
   @each $bp-key, $bp-value in $nb-breakpoints {
     @include nb-respond-to($bp-key) {
-      .#{$nb-namespace}u-hidden\@#{$bp-key} {
+      .#{$nb-namespace}u-hidden#{$nb-breakpoint-class}#{$bp-key} {
         display: none !important;
       }
     }
     @include nb-respond-to('max-#{$bp-key}') {
-      .#{$nb-namespace}u-hidden\@max-#{$bp-key} {
+      .#{$nb-namespace}u-hidden#{$nb-breakpoint-class}max-#{$bp-key} {
         display: none !important;
       }
     }

--- a/nebula-css/tools/_list-spacing.scss
+++ b/nebula-css/tools/_list-spacing.scss
@@ -17,11 +17,11 @@
 
     @each $bp-key, $bp-value in $nb-breakpoints {
       @include nb-respond-to($bp-key) {
-        .#{$compound-class}\@#{$bp-key} {
+        .#{$compound-class}#{$nb-breakpoint-class}#{$bp-key} {
           margin-#{$side}: -$value;
         }
 
-        .#{$compound-class}\@#{$bp-key} > .#{$nb-namespace}o-#{$class}__item {
+        .#{$compound-class}#{$nb-breakpoint-class}#{$bp-key} > .#{$nb-namespace}o-#{$class}__item {
           padding-#{$side}: $value;
         }
       }

--- a/nebula-css/tools/_offsets.scss
+++ b/nebula-css/tools/_offsets.scss
@@ -25,7 +25,7 @@
       @each $key, $value in $fractions {
         $modifier: nb-str-replace($key, '/', '\\/');
         $offset-value: (($value * 100) * 1%);
-        .#{$nb-namespace}u-#{$class}#{$modifier}\@#{$bp-key} {
+        .#{$nb-namespace}u-#{$class}#{$modifier}#{$nb-breakpoint-class}#{$bp-key} {
           #{$property}: $offset-value;
         }
       }

--- a/nebula-css/tools/_section.scss
+++ b/nebula-css/tools/_section.scss
@@ -8,7 +8,7 @@
 
     @each $bp-key, $bp-value in $nb-breakpoints {
       @include nb-respond-to($bp-key) {
-        .#{$nb-namespace}o-section#{$class}\@#{$bp-key} {
+        .#{$nb-namespace}o-section#{$class}#{$nb-breakpoint-class}#{$bp-key} {
           padding-top: $value;
           padding-bottom: $value;
         }

--- a/nebula-css/tools/_spacing.scss
+++ b/nebula-css/tools/_spacing.scss
@@ -20,7 +20,7 @@
     @each $bp-key, $bp-value in $nb-breakpoints {
       @include nb-respond-to(#{$bp-key}) {
         @each $direction in $directions {
-          .#{$nb-namespace}u-#{$action}#{$direction}-#{$key}\@#{$bp-key} {
+          .#{$nb-namespace}u-#{$action}#{$direction}-#{$key}#{$nb-breakpoint-class}#{$bp-key} {
             #{$property}#{$direction}: $value !important;
           }
         }
@@ -51,24 +51,24 @@
 
   @each $key, $value in $nb-breakpoints {
     @include nb-respond-to(#{$key}) {
-      .#{$nb-namespace}u-#{$action}\@#{$key} {
+      .#{$nb-namespace}u-#{$action}#{$nb-breakpoint-class}#{$key} {
         #{$property}: 0 !important;
       }
 
       @each $direction in $directions {
-        .#{$nb-namespace}u-#{$action}#{$direction}\@#{$key} {
+        .#{$nb-namespace}u-#{$action}#{$direction}#{$nb-breakpoint-class}#{$key} {
           #{$property}#{$direction}: 0 !important;
         }
       }
     }
     $max-key: 'max-' + $key;
     @include nb-respond-to(#{$max-key}) {
-      .#{$nb-namespace}u-#{$action}\@#{$max-key} {
+      .#{$nb-namespace}u-#{$action}#{$nb-breakpoint-class}#{$max-key} {
         #{$property}: 0 !important;
       }
 
       @each $direction in $directions {
-        .#{$nb-namespace}u-#{$action}#{$direction}\@#{$max-key} {
+        .#{$nb-namespace}u-#{$action}#{$direction}#{$nb-breakpoint-class}#{$max-key} {
           #{$property}#{$direction}: 0 !important;
         }
       }

--- a/nebula-css/tools/_uniformed-list.scss
+++ b/nebula-css/tools/_uniformed-list.scss
@@ -1,7 +1,7 @@
 @mixin uniformed-list-properties($bp: null) {
   $bp-class: '';
   @if $bp {
-    $bp-class: '\\@#{$bp}';
+    $bp-class: '#{$nb-breakpoint-class}#{$bp}';
   }
 
   .#{$nb-namespace}o-uniformed-list#{$bp-class} {


### PR DESCRIPTION
It's not possible to escape some characters (among them `@`) with css module's `composes:`. I like the `@` but it's just not possible to use in some setups which makes the framework unusable. I've replaced the hard-coded `@` for responsive classes with a changeable setting that defaults to `@`.